### PR TITLE
fix: get_last_numeric_value picks wrong column in multi-year statements (returns oldest period instead of latest)

### DIFF
--- a/edgar_analytics/synonyms_utils.py
+++ b/edgar_analytics/synonyms_utils.py
@@ -9,6 +9,7 @@ investing activities minus intangible/business acquisition outflows if direct
 capex is not found.
 """
 
+import re
 import threading
 from typing import Optional
 
@@ -19,6 +20,8 @@ from .logging_utils import get_logger
 from .synonyms import SYNONYMS
 
 logger = get_logger(__name__)
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}")
 
 _EXPENSE_LABELS = frozenset((
     "cost_of_revenue", "operating_expenses", "rnd_expenses",
@@ -69,8 +72,20 @@ def get_normalized_index(df: pd.DataFrame) -> NormalizedIndex:
 
 
 def get_last_numeric_value(row_series, fallback: float = np.nan, debug_label: str = "(unknown)") -> float:
-    """Retrieve the last non-NaN numeric value from a row Series (right-to-left).
-    If a DataFrame is passed (duplicate index), uses the first row."""
+    """Retrieve the latest-period numeric value from a row Series.
+
+    Statement DataFrames produced by ``_convert_statement_df`` arrange
+    period columns *newest-leftmost* (e.g. ``["2025-09-27", "2024-09-28",
+    "2023-09-30"]`` for a 3-year 10-K). The latest period is therefore the
+    first non-NaN numeric value scanning left-to-right.
+
+    Also performs a defensive lookup: if any column names look like ISO
+    dates, pick the row's value at ``max(date_cols)`` first. This guards
+    against future edgartools format changes that might re-order columns.
+
+    Falls back to a left-to-right scan otherwise. If a DataFrame is passed
+    (duplicate index), uses the first row.
+    """
     if isinstance(row_series, pd.DataFrame):
         logger.debug("get_last_numeric_value(%s): got DataFrame (duplicate index), using first row", debug_label)
         row_series = row_series.iloc[0]
@@ -79,7 +94,20 @@ def get_last_numeric_value(row_series, fallback: float = np.nan, debug_label: st
         logger.debug("get_last_numeric_value(%s): input not a Series -> fallback=%s", debug_label, fallback)
         return fallback
 
-    for col in reversed(row_series.index):
+    # Date-aware pick: choose the column whose name parses as the latest
+    # ISO date. ISO format (YYYY-MM-DD) sorts correctly as a string.
+    date_cols = [c for c in row_series.index
+                 if isinstance(c, str) and _ISO_DATE_RE.match(c)]
+    if date_cols:
+        latest = max(date_cols)
+        val = row_series[latest]
+        if pd.notna(val):
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                pass  # fall through to scan
+
+    for col in row_series.index:
         val = row_series[col]
         if pd.notna(val):
             try:

--- a/tests/test_synonyms_utils.py
+++ b/tests/test_synonyms_utils.py
@@ -10,6 +10,7 @@ from edgar_analytics.synonyms_utils import (
     flip_sign_if_negative_expense,
     compute_capex_single_period,
     compute_capex_for_column,
+    get_last_numeric_value,
 )
 
 def test_find_synonym_value_no_match():
@@ -248,3 +249,43 @@ def test_partial_match_row_prefers_tighter_coverage():
     row = find_best_synonym_row(df, "revenue", debug_label="CoverageRowTest")
     assert row is not None
     assert row["2023"] == 300
+
+
+class TestGetLastNumericValue:
+    """Regression tests: _convert_statement_df orders period columns
+    newest-leftmost (e.g. 3-year 10-K: ['2025-09-27', '2024-09-28',
+    '2023-09-30']), so the latest period must be picked by date, not by
+    column position."""
+
+    def test_newest_leftmost_iso_columns_picks_latest(self):
+        row = pd.Series({"2025-09-27": 416161.0, "2024-09-28": 391035.0, "2023-09-30": 383285.0})
+        assert get_last_numeric_value(row) == pytest.approx(416161.0)
+
+    def test_newest_rightmost_iso_columns_still_picks_latest(self):
+        """Defensive: works regardless of column order, not just newest-leftmost."""
+        row = pd.Series({"2023-09-30": 383285.0, "2024-09-28": 391035.0, "2025-09-27": 416161.0})
+        assert get_last_numeric_value(row) == pytest.approx(416161.0)
+
+    def test_leading_nan_in_latest_column_falls_back_to_next_available(self):
+        row = pd.Series({"2025-09-27": np.nan, "2024-09-28": 391035.0, "2023-09-30": 383285.0})
+        assert get_last_numeric_value(row) == pytest.approx(391035.0)
+
+    def test_non_date_labels_scan_left_to_right(self):
+        """Single-column ('Value'-style) rows have no date columns at all;
+        must fall back to a plain left-to-right scan."""
+        row = pd.Series({"Value": 500.0})
+        assert get_last_numeric_value(row) == pytest.approx(500.0)
+
+    def test_all_nan_returns_fallback(self):
+        row = pd.Series({"2025-09-27": np.nan, "2024-09-28": np.nan})
+        assert get_last_numeric_value(row, fallback=0.0) == 0.0
+
+    def test_find_synonym_value_multi_year_picks_latest_period(self):
+        """End-to-end: find_synonym_value on a newest-leftmost 3-year statement
+        must return the latest year's value, not the oldest."""
+        df = pd.DataFrame(
+            {"2025-09-27": [416161.0], "2024-09-28": [391035.0], "2023-09-30": [383285.0]},
+            index=["Revenue"],
+        )
+        val = find_synonym_value(df, ["Revenue"], fallback=0.0, debug_label="MultiYearTest")
+        assert val == pytest.approx(416161.0)


### PR DESCRIPTION
## Summary

`get_last_numeric_value` in `synonyms_utils.py` walks row columns right-to-left and returns the first non-NaN value, assuming the *rightmost* column is the latest period. After commit 83ff79f ("edgartools 5.x compatibility — Statement DF format"), `_convert_statement_df` produces DataFrames where period columns are ordered **newest-leftmost**. The right-to-left scan therefore returns the *oldest* period instead of the latest.

Every metric extracted via `find_synonym_value` from a multi-year statement silently returns the wrong year. Single-period statements (10-Q with one period column) are not affected.

## Reproduction

```python
import edgar_analytics as ea
result = ea.analyze("AAPL", identity="Your Name <you@example.com>")
m = result.main.annual_snapshot.metrics
print(f"Revenue:    ${m.revenue/1e9:.1f}B")
print(f"Net income: ${m.net_income/1e9:.1f}B")
print(f"Filed:      {result.main.annual_snapshot.filing_info.filed_date}")
```

Output on current `main`:
```
Revenue:    $383.3B    ← AAPL FY2023 value
Net income:  $97.0B    ← AAPL FY2023 value
Filed:      2025-10-31 ← FY2025 10-K
```

Apple's actual FY2025 revenue is $416.16B (per the FY2025 10-K and investor relations press release). The library returns FY2023 numbers from the FY2025 filing.

Same issue reproduces on AESI's FY2025 10-K (filed 2026-02-24) — returns $614M revenue (FY2023) instead of $1,095M (FY2025). Likely affects any multi-year statement extraction across all companies.

## Root cause

edgartools' `Statement.to_dataframe()` returns columns in this order for a 3-year 10-K:
```
[concept, label, standard_concept,
 "2025-09-27 (FY)", "2024-09-28 (FY)", "2023-09-30 (FY)",
 level, abstract, dimension, ...]
```

`_convert_statement_df` strips metadata columns and keeps the period columns **in their original order** (newest leftmost). Then `get_last_numeric_value`:

```python
for col in reversed(row_series.index):
    val = row_series[col]
    if pd.notna(val):
        return float(val)
```

iterates right-to-left over `[2025, 2024, 2023]`, hits `2023` first.

The compat fix in 83ff79f updated the data-prep layer but did not update the value picker that consumes it.

## Fix

Date-aware lookup with left-to-right scan as fallback. Date-aware path also guards against any future column-ordering changes (works regardless of order — picks max date).

See the diff in this PR.

## Verification

With this PR applied:

| Metric | Before fix | After fix | Actual FY2025 (10-K + Apple PR) |
|---|---|---|---|
| Revenue | $383,285M | **$416,161M** | $416,161M ✓ |
| Net income | $96,995M | **$112,010M** | $112,010M ✓ |
| Operating income | $114,301M | **$133,050M** | $133,050M ✓ |
| Operating CF | $110,543M | **$111,482M** | $111,482M ✓ |
| Income tax | $16,741M | **$20,719M** | $20,719M ✓ |
| Total equity | $56,950M | **$73,733M** | $73,733M ✓ |

Test suite: **421 passed, 0 regressions** (2 pre-existing test failures in `test_cli.py::test_cli_no_peers` and `test_orchestrator.py::test_analyze_company_invalid_peer` are MagicMock pickling errors in the peer-fanout code path, unrelated to value extraction — they fail on `main` without this PR too).

## Notes / follow-ups

- The function name `get_last_numeric_value` is now misleading — it returns the *latest period* (by date or by left-to-right scan), not the rightmost-column value. Happy to do a rename in a follow-up PR if you prefer (e.g. `get_latest_numeric_value`).
- I noticed this while building a Python ↔ Postgres comparison harness (we already had SEC companyfacts ingested in our own DB and were diffing the two outputs). Edgar-analytics's metric/scoring formulas matched ours exactly once this column-picking bug was fixed — the library's math is correct, just the input was being read from the wrong year. Thank you for the work.
